### PR TITLE
Updated Metadata Structure

### DIFF
--- a/src/components/AvatarConnect.tsx
+++ b/src/components/AvatarConnect.tsx
@@ -59,11 +59,7 @@ const AvatarConnect: FC = () => {
         fileExtension: bridgeResult.avatar.format,
         source: 'avatar-connect-' + bridgeResult.provider,
         category: 'avatar',
-        metadata: {
-          format: bridgeResult.avatar.format,
-          type: bridgeResult.avatar.type,
-          ...(bridgeResult.metadata as Record<string, unknown>)
-        }
+        metadata: bridgeResult.avatar
       };
       await api.post('/backpack/item/file', data);
       navigate('/');

--- a/src/components/AvatarConnect.tsx
+++ b/src/components/AvatarConnect.tsx
@@ -8,6 +8,7 @@ import { BridgeResult } from '@avatarconnect/sdk';
 import AvatarPreview from './AvatarPreview';
 import { AvatarErrorBoundary } from './AvatarErrorBoundary';
 import { sourceMapping } from '../utils/sourceMapping';
+import { mapBridgeResultToAvatarMetadata } from '../utils/avatarService';
 
 const AvatarConnect: FC = () => {
   const [store] = useStore();
@@ -59,8 +60,9 @@ const AvatarConnect: FC = () => {
         fileExtension: bridgeResult.avatar.format,
         source: 'avatar-connect-' + bridgeResult.provider,
         category: 'avatar',
-        metadata: bridgeResult.avatar
+        metadata: await mapBridgeResultToAvatarMetadata(bridgeResult)
       };
+
       await api.post('/backpack/item/file', data);
       navigate('/');
     }

--- a/src/utils/avatarService.tsx
+++ b/src/utils/avatarService.tsx
@@ -1,0 +1,69 @@
+import { BridgeResult } from '@avatarconnect/sdk';
+
+export interface AvatarMetadata {
+  source: string;
+  type: 'humanoid' | 'humanoid-male' | 'humanoid-female';
+  fileFormat: string;
+  reference?: string;
+  bodyType?: 'full-body' | 'half-body';
+  boneStructure?: {
+    head?: string;
+  };
+}
+
+export const mapBridgeResultToAvatarMetadata = async (
+  bridgeResult: BridgeResult
+): Promise<AvatarMetadata> => {
+  const metadata: AvatarMetadata = {
+    source: bridgeResult.provider,
+    type: getType(bridgeResult),
+    fileFormat: bridgeResult.avatar.format,
+    bodyType: getBodyType(bridgeResult)
+    //boneStructure: await getBoneStructure(bridgeResult)
+    // TODO: additional fields to be populated in the future
+  };
+
+  return metadata;
+};
+
+const getBodyType = (bridgeResult: BridgeResult): 'full-body' | 'half-body' => {
+  // eslint-disable-next-line
+  const metadata = bridgeResult.metadata as any;
+
+  if (bridgeResult.provider === 'ready-player-me' && metadata.bodyType) {
+    return metadata.bodyType === 'halfBody' ? 'half-body' : 'full-body';
+  }
+
+  return 'full-body';
+};
+
+const getType = (bridgeResult: BridgeResult): 'humanoid' | 'humanoid-male' | 'humanoid-female' => {
+  // eslint-disable-next-line
+  const metadata = bridgeResult.metadata as any;
+
+  if (bridgeResult.provider === 'ready-player-me' && metadata.gender) {
+    return metadata.outfitGender === 'masculine' ? 'humanoid-male' : 'humanoid-female';
+  }
+
+  return 'humanoid';
+};
+
+// TODO: Add bonestructure mapping
+/* const getBoneStructure = async (bridgeResult: BridgeResult) => {
+  if (bridgeResult.avatar.format === 'vrm') {
+    const loader = new GLTFLoader();
+    const gltf = await loader.loadAsync(bridgeResult.avatar.uri);
+    const headBone = 'head' as VRMSchema.HumanoidBoneName;
+    const vrm = await VRM.from(gltf);
+    const head = vrm?.humanoid?.getBoneNode(headBone);
+    if (head && head.name) {
+      console.log(head);
+      return {
+        head: head.name
+      };
+    }
+  }
+  return {
+    head: 'hi'
+  };
+};*/


### PR DESCRIPTION
## Problem
The metadata structure is inconsistent between providers. We're currently mixing standard properties with provider-controlled properties.

## Solution
Return the metadata in the same structure as the avatarconnect response. This way, standard properties will reliably exist on the metadata object and provider-related metadata can be structured independently.